### PR TITLE
chore: clang format indentation add for extern

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -39,6 +39,7 @@ IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentAccessModifiers: True
 IndentCaseBlocks: true
 IndentCaseLabels: true
+IndentExternBlock: true
 IndentWidth: 4
 InsertNewlineAtEOF: true
 MacroBlockBegin: ''


### PR DESCRIPTION
## Objectif
> Résumé : Nouvelle ligne pour clang format ajouté afin d'avoir une indentation pour les extern

## Liens et Contexte
- **Issue liée :** #
- **Documentation :** [Lien vers la doc si applicable]

## Nature des changements
- [ ] Nouvelle fonctionnalité (feature)
- [ ] Correction de bug (hotfix/bugfix)
- [ ] Amélioration des performances
- [x] Refactoring / Style du code
- [ ] Documentation
- [ ] Tests uniquement

## Validation & Tests

### Vérification manuelle
- [ ] Testé sur l'OS : ________

## Checklist Qualité
- [ ] J'ai commenté les parties complexes de mon code.
- [ ] J'ai mis à jour la documentation nécessaire.
- [ ] Aucun nouvel avertissement (warning) n'est généré.

---
*Signé : @florian-labadie *
