### PR TITLE
style: shortfunctionNotInline

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,6 +5,7 @@ AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignOperands: false
 AlignTrailingComments: false
+AllowShortFunctionsOnASingleLine: InlineOnly
 AlwaysBreakTemplateDeclarations: Yes
 BraceWrapping:
   AfterCaseLabel: true
@@ -13,7 +14,7 @@ BraceWrapping:
   AfterEnum: true
   AfterFunction: true
   AfterNamespace: false
-  AfterStruct: true
+  AfterStruct: false
   AfterUnion: true
   AfterExternBlock: false
   BeforeCatch: true


### PR DESCRIPTION
## Objectif
> Résumé : AJout ddans le format le fait qu'une fonction/méthodes peut être entièrement inline uniquement si elle est courte et dans un fichier headers

## Liens et Contexte
- **Issue liée :** #
- **Documentation :** [Lien vers la doc si applicable]

## Nature des changements
- [ ] Nouvelle fonctionnalité (feature)
- [ ] Correction de bug (hotfix/bugfix)
- [ ] Amélioration des performances
- [X] Refactoring / Style du code
- [ ] Documentation
- [ ] Tests uniquement

## Validation & Tests

### Vérification manuelle
- [ ] Testé sur l'OS : ________

## Checklist Qualité
- [ ] J'ai commenté les parties complexes de mon code.
- [ ] J'ai mis à jour la documentation nécessaire.
- [ ] Aucun nouvel avertissement (warning) n'est généré.

---
*Signé : @florian-labadie *
